### PR TITLE
feat: add support for ssh alias

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.58.1"
+channel = "1.82.0"
 components = ["rustfmt", "clippy"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,12 @@ struct Opts {
     /// Flag to turn off doc generation of private items
     #[clap(long, short = 'd')]
     disallow_private_items: bool,
+
+    /// If you use an ssh alias in order to use specific keys, you can specify the alias used for `github.com` here.
+    ///
+    /// See https://wiki.debian.org/SshAliases
+    #[clap(long, short)]
+    github_host_alias: Option<String>,
 }
 
 fn main() -> DynResult<()> {
@@ -62,7 +68,11 @@ fn main() -> DynResult<()> {
     Command::new("git")
         .args([
             "clone",
-            &format!("git@github.com:{}", &repo),
+            &format!(
+                "git@{}:{}",
+                opts.github_host_alias.unwrap_or_else(|| String::from("github.com")),
+                &repo
+            ),
             repo_path.as_os_str().to_str().unwrap(),
         ])
         .stderr(Stdio::inherit())


### PR DESCRIPTION
I have an alias set up for working in enterprise GitHub accounts to use specific ssh keys for those accounts. This PR allows for specifying the alias name so that ssh will use the correct keys.

I also updated the rust version.